### PR TITLE
fixup! fixup! [ADD] l10n_de_datev

### DIFF
--- a/l10n_de_datev/datev.py
+++ b/l10n_de_datev/datev.py
@@ -6,11 +6,12 @@ from collections import namedtuple, OrderedDict
 from io import StringIO
 
 
-DatevField = namedtuple(
-    "DatevField",
-    ("name", "length", "quote", "regex"),
-    defaults=(None, False, ".*"),
-)
+class DatevField:
+    def __init__(self, name, length=None, quote=False, regex=".*"):
+        self.name = name
+        self.length = length
+        self.quote = quote
+        self.regex = regex
 
 
 class DatevWriter(object):


### PR DESCRIPTION
Replaces `namedtuple` with a regular class as the `defaults` parameter is not available in `python3.6`.